### PR TITLE
Bump to Anchor v0.24.2

### DIFF
--- a/programs/anchor-escrow/Cargo.toml
+++ b/programs/anchor-escrow/Cargo.toml
@@ -15,6 +15,6 @@ no-entrypoint = []
 no-idl = []
 
 [dependencies]
-anchor-lang = "0.24.0"
-anchor-spl = {version = "0.24.0"}
+anchor-lang = "0.24.2"
+anchor-spl = {version = "0.24.2"}
 spl-token = {version = "3.3.0", features = ["no-entrypoint"]}

--- a/programs/anchor-escrow/Cargo.toml
+++ b/programs/anchor-escrow/Cargo.toml
@@ -15,6 +15,6 @@ no-entrypoint = []
 no-idl = []
 
 [dependencies]
-anchor-lang = "0.22.0"
-anchor-spl = {version = "0.22.0"}
+anchor-lang = "0.24.0"
+anchor-spl = {version = "0.24.0"}
 spl-token = {version = "3.3.0", features = ["no-entrypoint"]}


### PR DESCRIPTION
- I did not change the program id in `lib.rs` and `Anchor.toml`. I don't think that was necessary.