### PR TITLE
Update Anchor to v0.27.0

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,11 +1,11 @@
 [programs.localnet]
-anchor_escrow = "6m7hFFRbDoCAN5bTm592crzaXNV3qkYwt6aaEzd1rkg6"
+anchor_escrow = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 
 [registry]
 url = "https://anchor.projectserum.com"
 
 [provider]
-cluster = "https://rpc-mainnet-fork.epochs.studio"
+cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]

--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
 # Anchor Example: Escrow Program
 
-> See this [doc](https://book.solmeet.dev/notes/intro-to-anchor) for more implementation details
+> See this [doc](https://solmeet.gen3.network/notes/intro-to-anchor) for more implementation details
 
 ## Overview
 
 Since this program is extended from the original [Escrow Program](https://github.com/paul-schaaf/solana-escrow), I assumed you have gone through the [original blog post](https://paulx.dev/blog/2021/01/14/programming-on-solana-an-introduction/#instruction-rs-part-1-general-code-structure-and-the-beginning-of-the-escrow-program-flow) at least once.
 
-However, there is one major difference between this exmaple and the original Escrow program: Instead of letting initializer create a token account to be reset to a PDA authority, we create a token account `Vault` that has both a PDA key and a PDA authority.
+However, there is one major difference between this exmaple and the original Escrow program: Instead of letting initializer create a token account to be reset to a PDA authority, we create `Vault Authority(PDA)`'s associated token account (ATA) directly without transferring authority.
 
 #### Initialize
 
 ![](https://hackmd.io/_uploads/Hkn1gdtuj.png)
 
-`Initializer` can send a transaction to the escrow program to initialize the Vault. In this transaction, two new accounts: `Vault` and `EscrowState`, will be created and tokens (Token A) to be exchanged will be transfered from `Initializer` to `Vault`.
+`Initializer` can send a transaction to the escrow program to initialize the Vault. In this transaction, two new accounts: `Vault Authority's ATA` and `Escrow State`, will be created and tokens (Token A) to be exchanged will be transferred from `Initializer` to `Vault`(short for vault authority's ATA).
 
 #### Cancel
 
 ![](https://hackmd.io/_uploads/ry0GNdKdo.png)
 
-`Initializer` can also send a transaction to the escrow program to cancel the demand of escrow. The tokens will be transfered back to the `Initialzer` and both `Vault` and `EscrowState` will be closed in this case.
+`Initializer` can also send a transaction to the escrow program to cancel the demand of escrow. The tokens will be transferred back to the `Initializer` and both `Vault` and `Escrow State` will be closed in this case.
 
 #### Exchange
 
 ![](https://hackmd.io/_uploads/HkhNE_tdi.png)
 
-`Taker` can send a transaction to the escrow to exchange Token B for Token A. First, tokens (Token B) will be transfered from `Taker` to `Initializer`. Afterward, the tokens (Token A) kept in the Vault will be transfered to `Taker`. Finally, both `Vault` and `EscrowState` will be closed.
+`Taker` can send a transaction to the escrow to exchange Token B for Token A. First, tokens (Token B) will be transferred from `Taker` to `Initializer`. Afterward, the tokens (Token A) kept in the Vault will be transferred to `Taker`. Finally, both `Vault` and `Escrow State` will be closed.
 
 ## Install, Build, Deploy and Test
 
@@ -44,9 +44,9 @@ $ cargo install --git https://github.com/coral-xyz/anchor avm --locked --force
 Install latest `anchor` version:
 
 ```bash
-$ avm install 0.26.0
+$ avm install 0.27.0
 ...
-$ avm use 0.26.0
+$ avm use 0.27.0
 ...
 ```
 
@@ -67,7 +67,7 @@ Check if Anchor is successfully installed:
 
 ```bash
 $ anchor --version
-anchor-cli 0.26.0
+anchor-cli 0.27.0
 ```
 
 ### Install Dependencies
@@ -86,7 +86,7 @@ Get the public key of the deploy key. This keypair is generated automatically so
 
 ```bash
 $ anchor keys list
-anchor_escrow: GW65RiuuG2zU27S39FW83Yug1t13RxWWwHSCWRwSaybC
+anchor_escrow: Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS
 ```
 
 Replace the default value of `program_id` with this new value:
@@ -95,7 +95,7 @@ Replace the default value of `program_id` with this new value:
 # Anchor.toml
 
 [programs.localnet]
-anchor_escrow = "GW65RiuuG2zU27S39FW83Yug1t13RxWWwHSCWRwSaybC"
+anchor_escrow = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 
 ...
 ```
@@ -105,7 +105,7 @@ anchor_escrow = "GW65RiuuG2zU27S39FW83Yug1t13RxWWwHSCWRwSaybC"
 
 ...
 
-declare_id!("GW65RiuuG2zU27S39FW83Yug1t13RxWWwHSCWRwSaybC");
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
 ...
 ```
@@ -121,12 +121,7 @@ $ anchor build
 Let's deploy the program. Notice that `anchor-escrow` will be deployed on a [mainnet-fork](https://github.com/DappioWonderland/solana) test validator run by Dappio:
 
 ```
-$ solana config set --url https://rpc-mainnet-fork.epochs.studio
-...
-```
-
-```
-$ solana config set --ws wss://rpc-mainnet-fork.epochs.studio/ws
+$ solana config set --url localhost
 ...
 ```
 
@@ -134,7 +129,7 @@ $ solana config set --ws wss://rpc-mainnet-fork.epochs.studio/ws
 $ anchor deploy
 ...
 
-Program Id: GW65RiuuG2zU27S39FW83Yug1t13RxWWwHSCWRwSaybC
+Program Id: Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS
 
 Deploy success
 ```
@@ -142,5 +137,5 @@ Deploy success
 Finally, run the test:
 
 ```
-$ anchor test --skip-build --skip-deploy
+$ anchor test --skip-deploy --skip-build --skip-local-validator
 ```

--- a/package.json
+++ b/package.json
@@ -23,15 +23,15 @@
   },
   "homepage": "https://github.com/ironaddicteddog/anchor-escrow#readme",
   "dependencies": {
-    "@project-serum/anchor": "^0.26.0",
-    "@solana/spl-token": "^0.3.6"
+    "@coral-xyz/anchor": "^0.27.0",
+    "@solana/spl-token": "^0.3.7"
   },
   "devDependencies": {
     "@types/chai": "^4.3.4",
     "@types/mocha": "^9.0.0",
     "chai": "^4.3.4",
     "mocha": "^9.0.3",
-    "ts-mocha": "^8.0.0",
+    "ts-mocha": "^10.0.0",
     "typescript": "^4.3.5"
   }
 }

--- a/programs/anchor-escrow/Cargo.toml
+++ b/programs/anchor-escrow/Cargo.toml
@@ -15,5 +15,5 @@ no-entrypoint = []
 no-idl = []
 
 [dependencies]
-anchor-lang = "0.26.0"
-anchor-spl = "0.26.0"
+anchor-lang = "0.27.0"
+anchor-spl = "0.27.0"

--- a/programs/anchor-escrow/src/lib.rs
+++ b/programs/anchor-escrow/src/lib.rs
@@ -4,7 +4,7 @@ use anchor_spl::token::{
     TokenAccount, Transfer,
 };
 
-declare_id!("GW65RiuuG2zU27S39FW83Yug1t13RxWWwHSCWRwSaybC");
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
 #[program]
 pub mod anchor_escrow {

--- a/programs/anchor-escrow/src/lib.rs
+++ b/programs/anchor-escrow/src/lib.rs
@@ -9,7 +9,6 @@ pub mod anchor_escrow {
     use super::*;
 
     const AUTHORITY_SEED: &[u8] = b"authority";
-    const DECIMAL: u8 = 0;
 
     pub fn initialize(
         ctx: Context<Initialize>,
@@ -39,7 +38,7 @@ pub mod anchor_escrow {
         token::transfer_checked(
             ctx.accounts.into_transfer_to_pda_context(),
             ctx.accounts.escrow_state.initializer_amount,
-            DECIMAL,
+            ctx.accounts.mint.decimals,
         )?;
 
         Ok(())
@@ -56,7 +55,7 @@ pub mod anchor_escrow {
                 .into_transfer_to_initializer_context()
                 .with_signer(&[&authority_seeds[..]]),
             ctx.accounts.escrow_state.initializer_amount,
-            DECIMAL,
+            ctx.accounts.mint.decimals,
         )?;
 
         token::close_account(
@@ -77,7 +76,7 @@ pub mod anchor_escrow {
         token::transfer_checked(
             ctx.accounts.into_transfer_to_initializer_context(),
             ctx.accounts.escrow_state.taker_amount,
-            DECIMAL,
+            ctx.accounts.taker_deposit_token_mint.decimals,
         )?;
 
         token::transfer_checked(
@@ -85,7 +84,7 @@ pub mod anchor_escrow {
                 .into_transfer_to_taker_context()
                 .with_signer(&[&authority_seeds[..]]),
             ctx.accounts.escrow_state.initializer_amount,
-            DECIMAL,
+            ctx.accounts.initializer_deposit_token_mint.decimals,
         )?;
 
         token::close_account(

--- a/tests/anchor-escrow.ts
+++ b/tests/anchor-escrow.ts
@@ -1,5 +1,5 @@
-import * as anchor from "@project-serum/anchor";
-import NodeWallet from "@project-serum/anchor/dist/cjs/nodewallet";
+import * as anchor from "@coral-xyz/anchor";
+import NodeWallet from "@coral-xyz/anchor/dist/cjs/nodewallet";
 import { IDL } from "../target/types/anchor_escrow";
 import { PublicKey, SystemProgram, Transaction, Connection, Commitment } from "@solana/web3.js";
 import { TOKEN_PROGRAM_ID, createMint, createAccount, mintTo, getAccount } from "@solana/spl-token";
@@ -7,20 +7,25 @@ import { assert } from "chai";
 
 describe("anchor-escrow", () => {
   // Use Mainnet-fork for testing
-  const commitment: Commitment = "confirmed";
-  const connection = new Connection("https://rpc-mainnet-fork.epochs.studio", {
+  const commitment: Commitment = "processed"; // processed, confirmed, finalized
+  const connection = new Connection("http://localhost:8899", {
     commitment,
-    wsEndpoint: "wss://rpc-mainnet-fork.epochs.studio/ws",
+    wsEndpoint: "ws://localhost:8900/",
   });
+  // const connection = new Connection("https://api.devnet.solana.com", {
+  //   commitment,
+  //   wsEndpoint: "wss://api.devnet.solana.com/",
+  // });
+
   const options = anchor.AnchorProvider.defaultOptions();
   const wallet = NodeWallet.local();
   const provider = new anchor.AnchorProvider(connection, wallet, options);
 
   anchor.setProvider(provider);
 
-  // CAUTTION: if you are intended to use the program that is deployed by yourself,
+  // CAUTION: if you are intended to use the program that is deployed by yourself,
   // please make sure that the programIDs are consistent
-  const programId = new PublicKey("GW65RiuuG2zU27S39FW83Yug1t13RxWWwHSCWRwSaybC");
+  const programId = new PublicKey("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
   const program = new anchor.Program(IDL, programId, provider);
 
   let mintA = null as PublicKey;

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,10 +16,31 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
-"@coral-xyz/borsh@^0.26.0":
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/@coral-xyz/borsh/-/borsh-0.26.0.tgz#d054f64536d824634969e74138f9f7c52bbbc0d5"
-  integrity sha512-uCZ0xus0CszQPHYfWAqKS5swS1UxvePu83oOF+TWpUkedsNlg6p2p4azxZNSSqwXb9uXMFgxhuMBX9r3Xoi0vQ==
+"@coral-xyz/anchor@^0.27.0":
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/@coral-xyz/anchor/-/anchor-0.27.0.tgz#621e5ef123d05811b97e49973b4ed7ede27c705c"
+  integrity sha512-+P/vPdORawvg3A9Wj02iquxb4T0C5m4P6aZBVYysKl4Amk+r6aMPZkUhilBkD6E4Nuxnoajv3CFykUfkGE0n5g==
+  dependencies:
+    "@coral-xyz/borsh" "^0.27.0"
+    "@solana/web3.js" "^1.68.0"
+    base64-js "^1.5.1"
+    bn.js "^5.1.2"
+    bs58 "^4.0.1"
+    buffer-layout "^1.2.2"
+    camelcase "^6.3.0"
+    cross-fetch "^3.1.5"
+    crypto-hash "^1.3.0"
+    eventemitter3 "^4.0.7"
+    js-sha256 "^0.9.0"
+    pako "^2.0.3"
+    snake-case "^3.0.4"
+    superstruct "^0.15.4"
+    toml "^3.0.0"
+
+"@coral-xyz/borsh@^0.27.0":
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/@coral-xyz/borsh/-/borsh-0.27.0.tgz#700c647ea5262b1488957ac7fb4e8acf72c72b63"
+  integrity sha512-tJKzhLukghTWPLy+n8K8iJKgBq1yLT/AxaNd10yJrX8mI56ao5+OFAKAqW/h0i79KCvb4BK0VGO5ECmmolFz9A==
   dependencies:
     bn.js "^5.1.2"
     buffer-layout "^1.2.0"
@@ -39,27 +60,6 @@
   resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.7.0.tgz#d15357f7c227e751d90aa06b05a0e5cf993ba8c1"
   integrity sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw==
 
-"@project-serum/anchor@^0.26.0":
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/@project-serum/anchor/-/anchor-0.26.0.tgz#99e15a3923a5d10514f8185b2d3909e5699d60d5"
-  integrity sha512-Nq+COIjE1135T7qfnOHEn7E0q39bQTgXLFk837/rgFe6Hkew9WML7eHsS+lSYD2p3OJaTiUOHTAq1lHy36oIqQ==
-  dependencies:
-    "@coral-xyz/borsh" "^0.26.0"
-    "@solana/web3.js" "^1.68.0"
-    base64-js "^1.5.1"
-    bn.js "^5.1.2"
-    bs58 "^4.0.1"
-    buffer-layout "^1.2.2"
-    camelcase "^6.3.0"
-    cross-fetch "^3.1.5"
-    crypto-hash "^1.3.0"
-    eventemitter3 "^4.0.7"
-    js-sha256 "^0.9.0"
-    pako "^2.0.3"
-    snake-case "^3.0.4"
-    superstruct "^0.15.4"
-    toml "^3.0.0"
-
 "@solana/buffer-layout-utils@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz#b45a6cab3293a2eb7597cceb474f229889d875ca"
@@ -77,10 +77,10 @@
   dependencies:
     buffer "~6.0.3"
 
-"@solana/spl-token@^0.3.6":
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/@solana/spl-token/-/spl-token-0.3.6.tgz#35473ad2ed71fe91e5754a2ac72901e1b8b26a42"
-  integrity sha512-P9pTXjDIRvVbjr3J0mCnSamYqLnICeds7IoH1/Ro2R9OBuOHdp5pqKZoscfZ3UYrgnCWUc1bc9M2m/YPHjw+1g==
+"@solana/spl-token@^0.3.7":
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/@solana/spl-token/-/spl-token-0.3.7.tgz#6f027f9ad8e841f792c32e50920d9d2e714fc8da"
+  integrity sha512-bKGxWTtIw6VDdCBngjtsGlKGLSmiu/8ghSt/IOYJV24BsymRbgq7r12GToeetpxmPaZYLddKwAz7+EwprLfkfg==
   dependencies:
     "@solana/buffer-layout" "^4.0.0"
     "@solana/buffer-layout-utils" "^0.2.0"
@@ -1045,10 +1045,10 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
-ts-mocha@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/ts-mocha/-/ts-mocha-8.0.0.tgz#962d0fa12eeb6468aa1a6b594bb3bbc818da3ef0"
-  integrity sha512-Kou1yxTlubLnD5C3unlCVO7nh0HERTezjoVhVw/M5S1SqoUec0WgllQvPk3vzPMc6by8m6xD1uR1yRf8lnVUbA==
+ts-mocha@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/ts-mocha/-/ts-mocha-10.0.0.tgz#41a8d099ac90dbbc64b06976c5025ffaebc53cb9"
+  integrity sha512-VRfgDO+iiuJFlNB18tzOfypJ21xn2xbuZyDvJvqpTbWgkAgD17ONGr8t+Tl8rcBtOBdjXp5e/Rk+d39f7XBHRw==
   dependencies:
     ts-node "7.0.1"
   optionalDependencies:


### PR DESCRIPTION
This pull request includes updates for the Anchor framework to support versioned transactions. This enables new features and includes some optimizations. See the details below for more information.

- Bump Anchor to v0.27.0
- Replace `spl:transfer` with `spl:transfer_checked`
- Store bump into `escrow_state` to avoid redundant calculation in `cancel` and `exchange` instructions