### PR TITLE
Refactor

### DIFF
--- a/programs/anchor-escrow/src/contexts/cancel.rs
+++ b/programs/anchor-escrow/src/contexts/cancel.rs
@@ -1,0 +1,135 @@
+use anchor_lang::prelude::*;
+use anchor_spl::{
+    associated_token::AssociatedToken,
+    token::{
+        close_account, transfer_checked, CloseAccount, Mint, Token, TokenAccount, TransferChecked,
+    },
+};
+
+use crate::states::Escrow;
+
+#[derive(Accounts)]
+pub struct Cancel<'info> {
+    #[account(mut)]
+    initializer: Signer<'info>,
+    mint_a: Account<'info, Mint>,
+    #[account(
+        mut,
+        associated_token::mint = mint_a,
+        associated_token::authority = initializer
+    )]
+    initializer_ata_a: Account<'info, TokenAccount>,
+    #[account(
+        mut,
+        has_one = initializer,
+        has_one = mint_a,
+        close = initializer,
+        seeds=[b"state", escrow.seed.to_le_bytes().as_ref()],
+        bump = escrow.bump,
+    )]
+    escrow: Account<'info, Escrow>,
+    #[account(
+        mut,
+        associated_token::mint = mint_a,
+        associated_token::authority = escrow
+    )]
+    pub vault: Account<'info, TokenAccount>,
+    associated_token_program: Program<'info, AssociatedToken>,
+    token_program: Program<'info, Token>,
+    system_program: Program<'info, System>,
+}
+
+impl<'info> Cancel<'info> {
+    pub fn refund_and_close_vault(&mut self) -> Result<()> {
+        let signer_seeds: [&[&[u8]]; 1] = [&[
+            b"state",
+            &self.escrow.seed.to_le_bytes()[..],
+            &[self.escrow.bump],
+        ]];
+
+        transfer_checked(
+            self.into_refund_context().with_signer(&signer_seeds),
+            self.escrow.initializer_amount,
+            self.mint_a.decimals,
+        )?;
+
+        close_account(self.into_close_context().with_signer(&signer_seeds))
+
+        // let accounts = Transfer {
+        //     from: self.vault.to_account_info(),
+        //     to: self.maker_ata_a.to_account_info(),
+        //     authority: self.escrow.to_account_info(),
+        // };
+
+        // let ctx = CpiContext::new_with_signer(
+        //     self.token_program.to_account_info(),
+        //     accounts,
+        //     &signer_seeds,
+        // );
+
+        // transfer_checked(ctx, self.vault.amount, self.mint_a.decimals)?;
+
+        // let accounts = CloseAccount {
+        //     account: self.vault.to_account_info(),
+        //     destination: self.maker.to_account_info(),
+        //     authority: self.escrow.to_account_info(),
+        // };
+
+        // let ctx = CpiContext::new_with_signer(
+        //     self.token_program.to_account_info(),
+        //     accounts,
+        //     &signer_seeds,
+        // );
+
+        // token::close_account(
+        //     ctx.accounts
+        //         .into_close_context()
+        //         .with_signer(&[&authority_seeds[..]]),
+        // )?;
+    }
+
+    fn into_refund_context(&self) -> CpiContext<'_, '_, '_, 'info, TransferChecked<'info>> {
+        let cpi_accounts = TransferChecked {
+            from: self.vault.to_account_info(),
+            mint: self.mint_a.to_account_info(),
+            to: self.initializer_ata_a.to_account_info(),
+            authority: self.escrow.to_account_info(),
+        };
+        CpiContext::new(self.token_program.to_account_info(), cpi_accounts)
+    }
+
+    fn into_close_context(&self) -> CpiContext<'_, '_, '_, 'info, CloseAccount<'info>> {
+        let cpi_accounts = CloseAccount {
+            account: self.vault.to_account_info(),
+            destination: self.initializer.to_account_info(),
+            authority: self.escrow.to_account_info(),
+        };
+        CpiContext::new(self.token_program.to_account_info(), cpi_accounts)
+    }
+}
+// #[derive(Accounts)]
+// pub struct Cancel1<'info> {
+//     /// CHECK: This is not dangerous because we don't read or write from this account
+//     #[account(mut)]
+//     pub initializer: Signer<'info>,
+//     pub mint: Account<'info, Mint>,
+//     #[account(mut)]
+//     pub vault: Account<'info, TokenAccount>,
+//     /// CHECK: This is not dangerous because we don't read or write from this account
+//     #[account(
+//         seeds = [b"authority".as_ref()],
+//         bump,
+//     )]
+//     pub vault_authority: AccountInfo<'info>,
+//     #[account(mut)]
+//     pub initializer_deposit_token_account: Account<'info, TokenAccount>,
+//     #[account(
+//         mut,
+//         constraint = escrow_state.initializer_key == *initializer.key,
+//         constraint = escrow_state.initializer_deposit_token_account == *initializer_deposit_token_account.to_account_info().key,
+//         close = initializer
+//     )]
+//     pub escrow_state: Box<Account<'info, Escrow>>,
+//     /// CHECK: This is not dangerous because we don't read or write from this account
+//     pub token_program: Program<'info, Token>,
+// }

--- a/programs/anchor-escrow/src/contexts/cancel.rs
+++ b/programs/anchor-escrow/src/contexts/cancel.rs
@@ -54,38 +54,6 @@ impl<'info> Cancel<'info> {
         )?;
 
         close_account(self.into_close_context().with_signer(&signer_seeds))
-
-        // let accounts = Transfer {
-        //     from: self.vault.to_account_info(),
-        //     to: self.maker_ata_a.to_account_info(),
-        //     authority: self.escrow.to_account_info(),
-        // };
-
-        // let ctx = CpiContext::new_with_signer(
-        //     self.token_program.to_account_info(),
-        //     accounts,
-        //     &signer_seeds,
-        // );
-
-        // transfer_checked(ctx, self.vault.amount, self.mint_a.decimals)?;
-
-        // let accounts = CloseAccount {
-        //     account: self.vault.to_account_info(),
-        //     destination: self.maker.to_account_info(),
-        //     authority: self.escrow.to_account_info(),
-        // };
-
-        // let ctx = CpiContext::new_with_signer(
-        //     self.token_program.to_account_info(),
-        //     accounts,
-        //     &signer_seeds,
-        // );
-
-        // token::close_account(
-        //     ctx.accounts
-        //         .into_close_context()
-        //         .with_signer(&[&authority_seeds[..]]),
-        // )?;
     }
 
     fn into_refund_context(&self) -> CpiContext<'_, '_, '_, 'info, TransferChecked<'info>> {
@@ -107,29 +75,3 @@ impl<'info> Cancel<'info> {
         CpiContext::new(self.token_program.to_account_info(), cpi_accounts)
     }
 }
-// #[derive(Accounts)]
-// pub struct Cancel1<'info> {
-//     /// CHECK: This is not dangerous because we don't read or write from this account
-//     #[account(mut)]
-//     pub initializer: Signer<'info>,
-//     pub mint: Account<'info, Mint>,
-//     #[account(mut)]
-//     pub vault: Account<'info, TokenAccount>,
-//     /// CHECK: This is not dangerous because we don't read or write from this account
-//     #[account(
-//         seeds = [b"authority".as_ref()],
-//         bump,
-//     )]
-//     pub vault_authority: AccountInfo<'info>,
-//     #[account(mut)]
-//     pub initializer_deposit_token_account: Account<'info, TokenAccount>,
-//     #[account(
-//         mut,
-//         constraint = escrow_state.initializer_key == *initializer.key,
-//         constraint = escrow_state.initializer_deposit_token_account == *initializer_deposit_token_account.to_account_info().key,
-//         close = initializer
-//     )]
-//     pub escrow_state: Box<Account<'info, Escrow>>,
-//     /// CHECK: This is not dangerous because we don't read or write from this account
-//     pub token_program: Program<'info, Token>,
-// }

--- a/programs/anchor-escrow/src/contexts/exchange.rs
+++ b/programs/anchor-escrow/src/contexts/exchange.rs
@@ -1,0 +1,112 @@
+use anchor_lang::prelude::*;
+use anchor_spl::{
+    associated_token::AssociatedToken,
+    token::{
+        close_account, transfer_checked, CloseAccount, Mint, Token, TokenAccount, TransferChecked,
+    },
+};
+
+use crate::states::Escrow;
+
+#[derive(Accounts)]
+pub struct Exchange<'info> {
+    #[account(mut)]
+    pub taker: Signer<'info>,
+    #[account(mut)]
+    pub initializer: SystemAccount<'info>,
+    pub mint_a: Account<'info, Mint>,
+    pub mint_b: Account<'info, Mint>,
+    #[account(
+        init_if_needed,
+        payer = taker,
+        associated_token::mint = mint_a,
+        associated_token::authority = taker
+    )]
+    pub taker_ata_a: Account<'info, TokenAccount>,
+    #[account(
+        mut,
+        associated_token::mint = mint_b,
+        associated_token::authority = taker
+    )]
+    pub taker_ata_b: Account<'info, TokenAccount>,
+    #[account(
+        init_if_needed,
+        payer = taker,
+        associated_token::mint = mint_b,
+        associated_token::authority = initializer
+    )]
+    pub initializer_ata_b: Account<'info, TokenAccount>,
+    #[account(
+        mut,
+        has_one = mint_b,
+        constraint = taker_ata_b.amount >= escrow.taker_amount,
+        close = initializer,
+        seeds=[b"state", escrow.seed.to_le_bytes().as_ref()],
+        bump = escrow.bump,
+    )]
+    pub escrow: Account<'info, Escrow>,
+    #[account(
+        mut,
+        associated_token::mint = mint_a,
+        associated_token::authority = escrow
+    )]
+    pub vault: Account<'info, TokenAccount>,
+    pub associated_token_program: Program<'info, AssociatedToken>,
+    pub token_program: Program<'info, Token>,
+    pub system_program: Program<'info, System>,
+}
+
+impl<'info> Exchange<'info> {
+    pub fn deposit(&mut self) -> Result<()> {
+        transfer_checked(
+            self.into_deposit_context(),
+            self.escrow.taker_amount,
+            self.mint_b.decimals,
+        )
+    }
+
+    pub fn withdraw_and_close_vault(&mut self) -> Result<()> {
+        let signer_seeds: [&[&[u8]]; 1] = [&[
+            b"state",
+            &self.escrow.seed.to_le_bytes()[..],
+            &[self.escrow.bump],
+        ]];
+
+        transfer_checked(
+            self.into_withdraw_context().with_signer(&signer_seeds),
+            self.escrow.initializer_amount,
+            self.mint_a.decimals,
+        )?;
+
+        close_account(self.into_close_context().with_signer(&signer_seeds))
+    }
+
+    fn into_deposit_context(&self) -> CpiContext<'_, '_, '_, 'info, TransferChecked<'info>> {
+        let cpi_accounts = TransferChecked {
+            from: self.taker_ata_b.to_account_info(),
+            mint: self.mint_b.to_account_info(),
+            to: self.initializer_ata_b.to_account_info(),
+            authority: self.taker.to_account_info(),
+        };
+        CpiContext::new(self.token_program.to_account_info(), cpi_accounts)
+    }
+
+    fn into_withdraw_context(&self) -> CpiContext<'_, '_, '_, 'info, TransferChecked<'info>> {
+        let cpi_accounts = TransferChecked {
+            from: self.vault.to_account_info(),
+            mint: self.mint_a.to_account_info(),
+            to: self.taker_ata_a.to_account_info(),
+            authority: self.escrow.to_account_info(),
+        };
+        CpiContext::new(self.token_program.to_account_info(), cpi_accounts)
+    }
+
+    fn into_close_context(&self) -> CpiContext<'_, '_, '_, 'info, CloseAccount<'info>> {
+        let cpi_accounts = CloseAccount {
+            account: self.vault.to_account_info(),
+            destination: self.initializer.to_account_info(),
+            authority: self.escrow.to_account_info(),
+        };
+        CpiContext::new(self.token_program.to_account_info(), cpi_accounts)
+    }
+}

--- a/programs/anchor-escrow/src/contexts/initialize.rs
+++ b/programs/anchor-escrow/src/contexts/initialize.rs
@@ -6,7 +6,7 @@ use anchor_spl::{
 };
 
 #[derive(Accounts)]
-#[instruction(seed: u64)]
+#[instruction(seed: u64, initializer_amount: u64)]
 pub struct Initialize<'info> {
     #[account(mut)]
     pub initializer: Signer<'info>,
@@ -14,6 +14,7 @@ pub struct Initialize<'info> {
     pub mint_b: Account<'info, Mint>,
     #[account(
         mut,
+        constraint = initializer_ata_a.amount >= initializer_amount,
         associated_token::mint = mint_a,
         associated_token::authority = initializer
     )]
@@ -36,7 +37,6 @@ pub struct Initialize<'info> {
     pub associated_token_program: Program<'info, AssociatedToken>,
     pub token_program: Program<'info, Token>,
     pub system_program: Program<'info, System>,
-    pub rent: Sysvar<'info, Rent>,
 }
 
 impl<'info> Initialize<'info> {
@@ -77,43 +77,3 @@ impl<'info> Initialize<'info> {
         CpiContext::new(self.token_program.to_account_info(), cpi_accounts)
     }
 }
-
-// #[instruction(seed: u64,)]
-// pub struct Initialize1<'info> {
-//     /// CHECK: This is not dangerous because we don't read or write from this account
-//     #[account(mut)]
-//     pub initializer: Signer<'info>,
-//     pub mint_a: Account<'info, Mint>,
-//     pub mint_b: Account<'info, Mint>,
-//     #[account(
-//         init_if_needed,
-//         payer = initializer,
-//         associated_token::mint = mint_a,
-//         associated_token::authority = escrow_state
-//     )]
-//     pub vault: Box<Account<'info, TokenAccount>>,
-//     #[account(mut)]
-//     pub initializer_deposit_token_account: Account<'info, TokenAccount>,
-//     #[account(
-//         init_if_needed,
-//         payer = initializer,
-//         associated_token::mint = mint_b,
-//         associated_token::authority = initializer
-//     )]
-//     pub initializer_receive_token_account: Account<'info, TokenAccount>,
-//     #[account(
-//         init,
-//         seeds = [b"state".as_ref(), &random_seed.to_le_bytes(),initializer.key().as_ref()],
-//         bump ,
-//         payer = initializer,
-//         space = Escrow::INIT_SPACE
-//     )]
-//     pub escrow_state: Box<Account<'info, Escrow>>,
-//     /// CHECK: This is not dangerous because we don't read or write from this account
-//     pub system_program: Program<'info, System>,
-//     pub rent: Sysvar<'info, Rent>,
-//     /// CHECK: This is not dangerous because we don't read or write from this account
-//     pub token_program: Program<'info, Token>,
-//     /// CHECK: This is not dangerous because we don't read or write from this account
-//     pub associated_token_program: Program<'info, AssociatedToken>,
-// }

--- a/programs/anchor-escrow/src/contexts/initialize.rs
+++ b/programs/anchor-escrow/src/contexts/initialize.rs
@@ -1,9 +1,10 @@
-use crate::states::Escrow;
 use anchor_lang::prelude::*;
 use anchor_spl::{
     associated_token::AssociatedToken,
     token::{transfer_checked, Mint, Token, TokenAccount, TransferChecked},
 };
+
+use crate::states::Escrow;
 
 #[derive(Accounts)]
 #[instruction(seed: u64, initializer_amount: u64)]
@@ -20,7 +21,7 @@ pub struct Initialize<'info> {
     )]
     pub initializer_ata_a: Account<'info, TokenAccount>,
     #[account(
-        init,
+        init_if_needed,
         payer = initializer,
         space = Escrow::INIT_SPACE,
         seeds = [b"state".as_ref(), &seed.to_le_bytes()],
@@ -28,7 +29,7 @@ pub struct Initialize<'info> {
     )]
     pub escrow: Account<'info, Escrow>,
     #[account(
-        init,
+        init_if_needed,
         payer = initializer,
         associated_token::mint = mint_a,
         associated_token::authority = escrow

--- a/programs/anchor-escrow/src/contexts/initialize.rs
+++ b/programs/anchor-escrow/src/contexts/initialize.rs
@@ -1,0 +1,119 @@
+use crate::states::Escrow;
+use anchor_lang::prelude::*;
+use anchor_spl::{
+    associated_token::AssociatedToken,
+    token::{transfer_checked, Mint, Token, TokenAccount, TransferChecked},
+};
+
+#[derive(Accounts)]
+#[instruction(seed: u64)]
+pub struct Initialize<'info> {
+    #[account(mut)]
+    pub initializer: Signer<'info>,
+    pub mint_a: Account<'info, Mint>,
+    pub mint_b: Account<'info, Mint>,
+    #[account(
+        mut,
+        associated_token::mint = mint_a,
+        associated_token::authority = initializer
+    )]
+    pub initializer_ata_a: Account<'info, TokenAccount>,
+    #[account(
+        init,
+        payer = initializer,
+        space = Escrow::INIT_SPACE,
+        seeds = [b"state".as_ref(), &seed.to_le_bytes()],
+        bump
+    )]
+    pub escrow: Account<'info, Escrow>,
+    #[account(
+        init,
+        payer = initializer,
+        associated_token::mint = mint_a,
+        associated_token::authority = escrow
+    )]
+    pub vault: Account<'info, TokenAccount>,
+    pub associated_token_program: Program<'info, AssociatedToken>,
+    pub token_program: Program<'info, Token>,
+    pub system_program: Program<'info, System>,
+    pub rent: Sysvar<'info, Rent>,
+}
+
+impl<'info> Initialize<'info> {
+    pub fn initialize_escrow(
+        &mut self,
+        seed: u64,
+        bumps: &InitializeBumps,
+        initializer_amount: u64,
+        taker_amount: u64,
+    ) -> Result<()> {
+        self.escrow.set_inner(Escrow {
+            seed,
+            bump: bumps.escrow,
+            initializer: self.initializer.key(),
+            mint_a: self.mint_a.key(),
+            mint_b: self.mint_b.key(),
+            initializer_amount,
+            taker_amount,
+        });
+        Ok(())
+    }
+
+    pub fn deposit(&mut self, initializer_amount: u64) -> Result<()> {
+        transfer_checked(
+            self.into_deposit_context(),
+            initializer_amount,
+            self.mint_a.decimals,
+        )
+    }
+
+    fn into_deposit_context(&self) -> CpiContext<'_, '_, '_, 'info, TransferChecked<'info>> {
+        let cpi_accounts = TransferChecked {
+            from: self.initializer_ata_a.to_account_info(),
+            mint: self.mint_a.to_account_info(),
+            to: self.vault.to_account_info(),
+            authority: self.initializer.to_account_info(),
+        };
+        CpiContext::new(self.token_program.to_account_info(), cpi_accounts)
+    }
+}
+
+// #[instruction(seed: u64,)]
+// pub struct Initialize1<'info> {
+//     /// CHECK: This is not dangerous because we don't read or write from this account
+//     #[account(mut)]
+//     pub initializer: Signer<'info>,
+//     pub mint_a: Account<'info, Mint>,
+//     pub mint_b: Account<'info, Mint>,
+//     #[account(
+//         init_if_needed,
+//         payer = initializer,
+//         associated_token::mint = mint_a,
+//         associated_token::authority = escrow_state
+//     )]
+//     pub vault: Box<Account<'info, TokenAccount>>,
+//     #[account(mut)]
+//     pub initializer_deposit_token_account: Account<'info, TokenAccount>,
+//     #[account(
+//         init_if_needed,
+//         payer = initializer,
+//         associated_token::mint = mint_b,
+//         associated_token::authority = initializer
+//     )]
+//     pub initializer_receive_token_account: Account<'info, TokenAccount>,
+//     #[account(
+//         init,
+//         seeds = [b"state".as_ref(), &random_seed.to_le_bytes(),initializer.key().as_ref()],
+//         bump ,
+//         payer = initializer,
+//         space = Escrow::INIT_SPACE
+//     )]
+//     pub escrow_state: Box<Account<'info, Escrow>>,
+//     /// CHECK: This is not dangerous because we don't read or write from this account
+//     pub system_program: Program<'info, System>,
+//     pub rent: Sysvar<'info, Rent>,
+//     /// CHECK: This is not dangerous because we don't read or write from this account
+//     pub token_program: Program<'info, Token>,
+//     /// CHECK: This is not dangerous because we don't read or write from this account
+//     pub associated_token_program: Program<'info, AssociatedToken>,
+// }

--- a/programs/anchor-escrow/src/contexts/mod.rs
+++ b/programs/anchor-escrow/src/contexts/mod.rs
@@ -1,2 +1,4 @@
 pub mod initialize;
 pub use initialize::*;
+pub mod cancel;
+pub use cancel::*;

--- a/programs/anchor-escrow/src/contexts/mod.rs
+++ b/programs/anchor-escrow/src/contexts/mod.rs
@@ -2,3 +2,5 @@ pub mod initialize;
 pub use initialize::*;
 pub mod cancel;
 pub use cancel::*;
+pub mod exchange;
+pub use exchange::*;

--- a/programs/anchor-escrow/src/contexts/mod.rs
+++ b/programs/anchor-escrow/src/contexts/mod.rs
@@ -1,0 +1,2 @@
+pub mod initialize;
+pub use initialize::*;

--- a/programs/anchor-escrow/src/lib.rs
+++ b/programs/anchor-escrow/src/lib.rs
@@ -1,18 +1,13 @@
 use anchor_lang::prelude::*;
-use anchor_spl::associated_token::AssociatedToken;
-use anchor_spl::token::{self, CloseAccount, Mint, Token, TokenAccount, TransferChecked};
-
-declare_id!("D3B39yETxmG29V3QPPNsdEzxQyonU5tjiwEr3svnMoRt");
-
 mod contexts;
 use contexts::*;
 mod states;
 
+declare_id!("D3B39yETxmG29V3QPPNsdEzxQyonU5tjiwEr3svnMoRt");
+
 #[program]
 pub mod anchor_escrow {
     use super::*;
-
-    const AUTHORITY_SEED: &[u8] = b"authority"; // To be deprecated
 
     pub fn initialize(
         ctx: Context<Initialize>,
@@ -22,259 +17,15 @@ pub mod anchor_escrow {
     ) -> Result<()> {
         ctx.accounts
             .initialize_escrow(seed, &ctx.bumps, initializer_amount, taker_amount)?;
-        ctx.accounts.deposit(initializer_amount)?;
-
-        Ok(())
+        ctx.accounts.deposit(initializer_amount)
     }
 
     pub fn cancel(ctx: Context<Cancel>) -> Result<()> {
-        ctx.accounts.refund_and_close_vault()?;
-
-        // let authority_seeds = &[
-        //     &AUTHORITY_SEED[..],
-        //     &[ctx.accounts.escrow_state.vault_authority_bump],
-        // ];
-
-        // token::transfer_checked(
-        //     ctx.accounts
-        //         .into_transfer_to_initializer_context()
-        //         .with_signer(&[&authority_seeds[..]]),
-        //     ctx.accounts.escrow_state.initializer_amount,
-        //     ctx.accounts.mint.decimals,
-        // )?;
-
-        // token::close_account(
-        //     ctx.accounts
-        //         .into_close_context()
-        //         .with_signer(&[&authority_seeds[..]]),
-        // )?;
-
-        Ok(())
+        ctx.accounts.refund_and_close_vault()
     }
 
     pub fn exchange(ctx: Context<Exchange>) -> Result<()> {
-        let authority_seeds = &[
-            &AUTHORITY_SEED[..],
-            &[ctx.accounts.escrow_state.vault_authority_bump],
-        ];
-
-        token::transfer_checked(
-            ctx.accounts.into_transfer_to_initializer_context(),
-            ctx.accounts.escrow_state.taker_amount,
-            ctx.accounts.taker_deposit_token_mint.decimals,
-        )?;
-
-        token::transfer_checked(
-            ctx.accounts
-                .into_transfer_to_taker_context()
-                .with_signer(&[&authority_seeds[..]]),
-            ctx.accounts.escrow_state.initializer_amount,
-            ctx.accounts.initializer_deposit_token_mint.decimals,
-        )?;
-
-        token::close_account(
-            ctx.accounts
-                .into_close_context()
-                .with_signer(&[&authority_seeds[..]]),
-        )?;
-
-        Ok(())
-    }
-}
-
-// #[derive(Accounts)]
-// #[instruction(escrow_seed: u64, initializer_amount: u64)]
-// pub struct Initialize<'info> {
-//     /// CHECK: This is not dangerous because we don't read or write from this account
-//     #[account(mut)]
-//     pub initializer: Signer<'info>,
-//     pub mint: Account<'info, Mint>,
-//     /// CHECK: This is not dangerous because we don't read or write from this account
-//     #[account(
-//         seeds = [b"authority".as_ref()],
-//         bump,
-//     )]
-//     pub vault_authority: AccountInfo<'info>,
-//     #[account(
-//         init,
-//         payer = initializer,
-//         associated_token::mint = mint,
-//         associated_token::authority = vault_authority
-//     )]
-//     pub vault: Box<Account<'info, TokenAccount>>,
-//     #[account(
-//         mut,
-//         constraint = initializer_deposit_token_account.amount >= initializer_amount
-//     )]
-//     pub initializer_deposit_token_account: Account<'info, TokenAccount>,
-//     pub initializer_receive_token_account: Account<'info, TokenAccount>,
-//     #[account(
-//         init,
-//         seeds = [b"state".as_ref(), &escrow_seed.to_le_bytes()],
-//         bump,
-//         payer = initializer,
-//         space = EscrowState::space()
-//     )]
-//     pub escrow_state: Box<Account<'info, EscrowState>>,
-//     /// CHECK: This is not dangerous because we don't read or write from this account
-//     pub system_program: Program<'info, System>,
-//     pub rent: Sysvar<'info, Rent>,
-//     /// CHECK: This is not dangerous because we don't read or write from this account
-//     pub token_program: Program<'info, Token>,
-//     /// CHECK: This is not dangerous because we don't read or write from this account
-//     pub associated_token_program: Program<'info, AssociatedToken>,
-// }
-
-// #[derive(Accounts)]
-// pub struct Cancel<'info> {
-//     /// CHECK: This is not dangerous because we don't read or write from this account
-//     #[account(mut)]
-//     pub initializer: Signer<'info>,
-//     pub mint: Account<'info, Mint>,
-//     #[account(mut)]
-//     pub vault: Account<'info, TokenAccount>,
-//     /// CHECK: This is not dangerous because we don't read or write from this account
-//     #[account(
-//         seeds = [b"authority".as_ref()],
-//         bump,
-//     )]
-//     pub vault_authority: AccountInfo<'info>,
-//     #[account(mut)]
-//     pub initializer_deposit_token_account: Account<'info, TokenAccount>,
-//     #[account(
-//         mut,
-//         constraint = escrow_state.initializer_key == *initializer.key,
-//         constraint = escrow_state.initializer_deposit_token_account == *initializer_deposit_token_account.to_account_info().key,
-//         close = initializer
-//     )]
-//     pub escrow_state: Box<Account<'info, EscrowState>>,
-//     /// CHECK: This is not dangerous because we don't read or write from this account
-//     pub token_program: Program<'info, Token>,
-// }
-
-#[derive(Accounts)]
-pub struct Exchange<'info> {
-    /// CHECK: This is not dangerous because we don't read or write from this account
-    pub taker: Signer<'info>,
-    pub initializer_deposit_token_mint: Account<'info, Mint>,
-    pub taker_deposit_token_mint: Account<'info, Mint>,
-    #[account(mut)]
-    pub taker_deposit_token_account: Box<Account<'info, TokenAccount>>,
-    #[account(mut)]
-    pub taker_receive_token_account: Box<Account<'info, TokenAccount>>,
-    #[account(mut)]
-    pub initializer_deposit_token_account: Box<Account<'info, TokenAccount>>,
-    #[account(mut)]
-    pub initializer_receive_token_account: Box<Account<'info, TokenAccount>>,
-    /// CHECK: This is not dangerous because we don't read or write from this account
-    #[account(mut)]
-    pub initializer: AccountInfo<'info>,
-    #[account(
-        mut,
-        constraint = escrow_state.taker_amount <= taker_deposit_token_account.amount,
-        constraint = escrow_state.initializer_deposit_token_account == *initializer_deposit_token_account.to_account_info().key,
-        constraint = escrow_state.initializer_receive_token_account == *initializer_receive_token_account.to_account_info().key,
-        constraint = escrow_state.initializer_key == *initializer.key,
-        close = initializer
-    )]
-    pub escrow_state: Box<Account<'info, EscrowState>>,
-    #[account(mut)]
-    pub vault: Box<Account<'info, TokenAccount>>,
-    /// CHECK: This is not dangerous because we don't read or write from this account
-    #[account(
-        seeds = [b"authority".as_ref()],
-        bump,
-    )]
-    pub vault_authority: AccountInfo<'info>,
-    /// CHECK: This is not dangerous because we don't read or write from this account
-    pub token_program: Program<'info, Token>,
-}
-
-#[account]
-pub struct EscrowState {
-    pub random_seed: u64,
-    pub initializer_key: Pubkey,
-    pub initializer_deposit_token_account: Pubkey,
-    pub initializer_receive_token_account: Pubkey,
-    pub initializer_amount: u64,
-    pub taker_amount: u64,
-    pub vault_authority_bump: u8,
-}
-
-// impl EscrowState {
-//     pub fn space() -> usize {
-//         8 + 121
-//     }
-// }
-
-// impl<'info> Initialize<'info> {
-//     fn into_transfer_to_pda_context(
-//         &self,
-//     ) -> CpiContext<'_, '_, '_, 'info, TransferChecked<'info>> {
-//         let cpi_accounts = TransferChecked {
-//             from: self.initializer_deposit_token_account.to_account_info(),
-//             mint: self.mint.to_account_info(),
-//             to: self.vault.to_account_info(),
-//             authority: self.initializer.to_account_info(),
-//         };
-//         CpiContext::new(self.token_program.to_account_info(), cpi_accounts)
-//     }
-// }
-
-// impl<'info> Cancel<'info> {
-//     fn into_transfer_to_initializer_context(
-//         &self,
-//     ) -> CpiContext<'_, '_, '_, 'info, TransferChecked<'info>> {
-//         let cpi_accounts = TransferChecked {
-//             from: self.vault.to_account_info(),
-//             mint: self.mint.to_account_info(),
-//             to: self.initializer_deposit_token_account.to_account_info(),
-//             authority: self.vault_authority.clone(),
-//         };
-//         CpiContext::new(self.token_program.to_account_info(), cpi_accounts)
-//     }
-
-//     fn into_close_context(&self) -> CpiContext<'_, '_, '_, 'info, CloseAccount<'info>> {
-//         let cpi_accounts = CloseAccount {
-//             account: self.vault.to_account_info(),
-//             destination: self.initializer.to_account_info(),
-//             authority: self.vault_authority.clone(),
-//         };
-//         CpiContext::new(self.token_program.to_account_info(), cpi_accounts)
-//     }
-// }
-
-impl<'info> Exchange<'info> {
-    fn into_transfer_to_initializer_context(
-        &self,
-    ) -> CpiContext<'_, '_, '_, 'info, TransferChecked<'info>> {
-        let cpi_accounts = TransferChecked {
-            from: self.taker_deposit_token_account.to_account_info(),
-            mint: self.taker_deposit_token_mint.to_account_info(),
-            to: self.initializer_receive_token_account.to_account_info(),
-            authority: self.taker.to_account_info(),
-        };
-        CpiContext::new(self.token_program.to_account_info(), cpi_accounts)
-    }
-
-    fn into_transfer_to_taker_context(
-        &self,
-    ) -> CpiContext<'_, '_, '_, 'info, TransferChecked<'info>> {
-        let cpi_accounts = TransferChecked {
-            from: self.vault.to_account_info(),
-            mint: self.initializer_deposit_token_mint.to_account_info(),
-            to: self.taker_receive_token_account.to_account_info(),
-            authority: self.vault_authority.clone(),
-        };
-        CpiContext::new(self.token_program.to_account_info(), cpi_accounts)
-    }
-
-    fn into_close_context(&self) -> CpiContext<'_, '_, '_, 'info, CloseAccount<'info>> {
-        let cpi_accounts = CloseAccount {
-            account: self.vault.to_account_info(),
-            destination: self.initializer.clone(),
-            authority: self.vault_authority.clone(),
-        };
-        CpiContext::new(self.token_program.to_account_info(), cpi_accounts)
+        ctx.accounts.deposit()?;
+        ctx.accounts.withdraw_and_close_vault()
     }
 }

--- a/programs/anchor-escrow/src/lib.rs
+++ b/programs/anchor-escrow/src/lib.rs
@@ -4,42 +4,25 @@ use anchor_spl::token::{self, CloseAccount, Mint, Token, TokenAccount, TransferC
 
 declare_id!("D3B39yETxmG29V3QPPNsdEzxQyonU5tjiwEr3svnMoRt");
 
+mod contexts;
+use contexts::*;
+mod states;
+
 #[program]
 pub mod anchor_escrow {
     use super::*;
 
-    const AUTHORITY_SEED: &[u8] = b"authority";
+    const AUTHORITY_SEED: &[u8] = b"authority"; // To be deprecated
 
     pub fn initialize(
         ctx: Context<Initialize>,
-        random_seed: u64,
+        seed: u64,
         initializer_amount: u64,
         taker_amount: u64,
     ) -> Result<()> {
-        ctx.accounts.escrow_state.initializer_key = *ctx.accounts.initializer.key;
-        ctx.accounts.escrow_state.initializer_deposit_token_account = *ctx
-            .accounts
-            .initializer_deposit_token_account
-            .to_account_info()
-            .key;
-        ctx.accounts.escrow_state.initializer_receive_token_account = *ctx
-            .accounts
-            .initializer_receive_token_account
-            .to_account_info()
-            .key;
-        ctx.accounts.escrow_state.initializer_amount = initializer_amount;
-        ctx.accounts.escrow_state.taker_amount = taker_amount;
-        ctx.accounts.escrow_state.random_seed = random_seed;
-
-        let (_vault_authority, vault_authority_bump) =
-            Pubkey::find_program_address(&[AUTHORITY_SEED], ctx.program_id);
-        ctx.accounts.escrow_state.vault_authority_bump = vault_authority_bump;
-
-        token::transfer_checked(
-            ctx.accounts.into_transfer_to_pda_context(),
-            ctx.accounts.escrow_state.initializer_amount,
-            ctx.accounts.mint.decimals,
-        )?;
+        ctx.accounts
+            .initialize_escrow(seed, &ctx.bumps, initializer_amount, taker_amount)?;
+        ctx.accounts.deposit(initializer_amount)?;
 
         Ok(())
     }
@@ -97,48 +80,48 @@ pub mod anchor_escrow {
     }
 }
 
-#[derive(Accounts)]
-#[instruction(escrow_seed: u64, initializer_amount: u64)]
-pub struct Initialize<'info> {
-    /// CHECK: This is not dangerous because we don't read or write from this account
-    #[account(mut)]
-    pub initializer: Signer<'info>,
-    pub mint: Account<'info, Mint>,
-    /// CHECK: This is not dangerous because we don't read or write from this account
-    #[account(
-        seeds = [b"authority".as_ref()],
-        bump,
-    )]
-    pub vault_authority: AccountInfo<'info>,
-    #[account(
-        init,
-        payer = initializer,
-        associated_token::mint = mint,
-        associated_token::authority = vault_authority
-    )]
-    pub vault: Box<Account<'info, TokenAccount>>,
-    #[account(
-        mut,
-        constraint = initializer_deposit_token_account.amount >= initializer_amount
-    )]
-    pub initializer_deposit_token_account: Account<'info, TokenAccount>,
-    pub initializer_receive_token_account: Account<'info, TokenAccount>,
-    #[account(
-        init,
-        seeds = [b"state".as_ref(), &escrow_seed.to_le_bytes()],
-        bump,
-        payer = initializer,
-        space = EscrowState::space()
-    )]
-    pub escrow_state: Box<Account<'info, EscrowState>>,
-    /// CHECK: This is not dangerous because we don't read or write from this account
-    pub system_program: Program<'info, System>,
-    pub rent: Sysvar<'info, Rent>,
-    /// CHECK: This is not dangerous because we don't read or write from this account
-    pub token_program: Program<'info, Token>,
-    /// CHECK: This is not dangerous because we don't read or write from this account
-    pub associated_token_program: Program<'info, AssociatedToken>,
-}
+// #[derive(Accounts)]
+// #[instruction(escrow_seed: u64, initializer_amount: u64)]
+// pub struct Initialize<'info> {
+//     /// CHECK: This is not dangerous because we don't read or write from this account
+//     #[account(mut)]
+//     pub initializer: Signer<'info>,
+//     pub mint: Account<'info, Mint>,
+//     /// CHECK: This is not dangerous because we don't read or write from this account
+//     #[account(
+//         seeds = [b"authority".as_ref()],
+//         bump,
+//     )]
+//     pub vault_authority: AccountInfo<'info>,
+//     #[account(
+//         init,
+//         payer = initializer,
+//         associated_token::mint = mint,
+//         associated_token::authority = vault_authority
+//     )]
+//     pub vault: Box<Account<'info, TokenAccount>>,
+//     #[account(
+//         mut,
+//         constraint = initializer_deposit_token_account.amount >= initializer_amount
+//     )]
+//     pub initializer_deposit_token_account: Account<'info, TokenAccount>,
+//     pub initializer_receive_token_account: Account<'info, TokenAccount>,
+//     #[account(
+//         init,
+//         seeds = [b"state".as_ref(), &escrow_seed.to_le_bytes()],
+//         bump,
+//         payer = initializer,
+//         space = EscrowState::space()
+//     )]
+//     pub escrow_state: Box<Account<'info, EscrowState>>,
+//     /// CHECK: This is not dangerous because we don't read or write from this account
+//     pub system_program: Program<'info, System>,
+//     pub rent: Sysvar<'info, Rent>,
+//     /// CHECK: This is not dangerous because we don't read or write from this account
+//     pub token_program: Program<'info, Token>,
+//     /// CHECK: This is not dangerous because we don't read or write from this account
+//     pub associated_token_program: Program<'info, AssociatedToken>,
+// }
 
 #[derive(Accounts)]
 pub struct Cancel<'info> {
@@ -222,19 +205,19 @@ impl EscrowState {
     }
 }
 
-impl<'info> Initialize<'info> {
-    fn into_transfer_to_pda_context(
-        &self,
-    ) -> CpiContext<'_, '_, '_, 'info, TransferChecked<'info>> {
-        let cpi_accounts = TransferChecked {
-            from: self.initializer_deposit_token_account.to_account_info(),
-            mint: self.mint.to_account_info(),
-            to: self.vault.to_account_info(),
-            authority: self.initializer.to_account_info(),
-        };
-        CpiContext::new(self.token_program.to_account_info(), cpi_accounts)
-    }
-}
+// impl<'info> Initialize<'info> {
+//     fn into_transfer_to_pda_context(
+//         &self,
+//     ) -> CpiContext<'_, '_, '_, 'info, TransferChecked<'info>> {
+//         let cpi_accounts = TransferChecked {
+//             from: self.initializer_deposit_token_account.to_account_info(),
+//             mint: self.mint.to_account_info(),
+//             to: self.vault.to_account_info(),
+//             authority: self.initializer.to_account_info(),
+//         };
+//         CpiContext::new(self.token_program.to_account_info(), cpi_accounts)
+//     }
+// }
 
 impl<'info> Cancel<'info> {
     fn into_transfer_to_initializer_context(

--- a/programs/anchor-escrow/src/states/escrow.rs
+++ b/programs/anchor-escrow/src/states/escrow.rs
@@ -1,0 +1,32 @@
+use anchor_lang::prelude::*;
+
+#[account]
+pub struct Escrow {
+    pub seed: u64,
+    pub bump: u8,
+    pub initializer: Pubkey,
+    pub mint_a: Pubkey,
+    pub mint_b: Pubkey,
+    pub initializer_amount: u64,
+    pub taker_amount: u64,
+}
+
+impl Space for Escrow {
+    // First 8 Bytes are Discriminator (u64)
+    const INIT_SPACE: usize = 8 + 8 + 1 + 32 + 32 + 32 + 8 + 8;
+}
+
+// impl EscrowState {
+//     pub fn space() -> usize {
+//         8 + 121
+//     }
+// }
+
+// #[account]
+// pub struct Escrow {
+//     pub seed: u64,
+//     pub mint_a: Pubkey,
+//     pub mint_b: Pubkey,
+//     pub receive: u64,
+//     pub bump: u8,
+// }

--- a/programs/anchor-escrow/src/states/mod.rs
+++ b/programs/anchor-escrow/src/states/mod.rs
@@ -1,0 +1,2 @@
+pub mod escrow;
+pub use escrow::Escrow;

--- a/tests/anchor-escrow.ts
+++ b/tests/anchor-escrow.ts
@@ -113,4 +113,14 @@ describe("anchor-escrow", () => {
       .then(confirm)
       .then(log);
   });
+
+  it("Cancel", async () => {
+    await program.methods
+      .cancel()
+      .accounts({ ...accounts })
+      .signers([initializer])
+      .rpc()
+      .then(confirm)
+      .then(log);
+  });
 });

--- a/tests/anchor-escrow.ts
+++ b/tests/anchor-escrow.ts
@@ -114,11 +114,21 @@ describe("anchor-escrow", () => {
       .then(log);
   });
 
-  it("Cancel", async () => {
+  xit("Cancel", async () => {
     await program.methods
       .cancel()
       .accounts({ ...accounts })
       .signers([initializer])
+      .rpc()
+      .then(confirm)
+      .then(log);
+  });
+
+  it("Exchange", async () => {
+    await program.methods
+      .exchange()
+      .accounts({ ...accounts })
+      .signers([taker])
       .rpc()
       .then(confirm)
       .then(log);

--- a/tests/anchor-escrow.ts
+++ b/tests/anchor-escrow.ts
@@ -1,270 +1,116 @@
 import * as anchor from "@coral-xyz/anchor";
-import NodeWallet from "@coral-xyz/anchor/dist/cjs/nodewallet";
-import { IDL } from "../target/types/anchor_escrow";
-import { PublicKey, SystemProgram, TransactionMessage, VersionedTransaction } from "@solana/web3.js";
+import { AnchorEscrow } from "../target/types/anchor_escrow";
+import { Keypair, LAMPORTS_PER_SOL, PublicKey, SystemProgram, Transaction } from "@solana/web3.js";
 import {
-  TOKEN_PROGRAM_ID,
   ASSOCIATED_TOKEN_PROGRAM_ID,
-  createMint,
-  createAccount,
-  mintTo,
-  getAccount,
+  MINT_SIZE,
+  TOKEN_PROGRAM_ID,
+  createAssociatedTokenAccountIdempotentInstruction,
+  createInitializeMint2Instruction,
+  createMintToInstruction,
+  getAssociatedTokenAddressSync,
+  getMinimumBalanceForRentExemptMint,
 } from "@solana/spl-token";
-import { assert } from "chai";
+import { randomBytes } from "crypto";
 
 describe("anchor-escrow", () => {
-  const wallet = anchor.AnchorProvider.env().wallet;
-  // Work-around: Get wallet private key
-  const walletKey = NodeWallet.local().payer;
-
+  // 0. Set provider, connection and program
   anchor.setProvider(anchor.AnchorProvider.env());
+  const provider = anchor.getProvider();
+  const connection = provider.connection;
+  const program = anchor.workspace.AnchorEscrow as anchor.Program<AnchorEscrow>;
 
-  // CAUTION: if you are intended to use the program that is deployed by yourself,
-  // please make sure that the programIDs are consistent
-  const programId = new PublicKey("D3B39yETxmG29V3QPPNsdEzxQyonU5tjiwEr3svnMoRt");
-  const program = new anchor.Program(IDL, programId, anchor.getProvider());
+  // 1. Boilerplate
+  // Determine dummy token mints and token account addresses
+  const [initializer, taker, mintA, mintB] = Array.from({ length: 4 }, () => Keypair.generate());
+  const [initializerAtaA, initializerAtaB, takerAtaA, takerAtaB] = [initializer, taker]
+    .map((a) => [mintA, mintB].map((m) => getAssociatedTokenAddressSync(m.publicKey, a.publicKey)))
+    .flat();
 
-  let mintA = null as PublicKey;
-  let mintB = null as PublicKey;
-  let initializerTokenAccountA = null as PublicKey;
-  let initializerTokenAccountB = null as PublicKey;
-  let takerTokenAccountA = null as PublicKey;
-  let takerTokenAccountB = null as PublicKey;
-
-  const takerAmount = 1000;
-  const initializerAmount = 500;
-
-  // Main Roles
-  const payer = anchor.web3.Keypair.generate();
-  const mintAuthority = anchor.web3.Keypair.generate();
-  const initializer = anchor.web3.Keypair.generate();
-  const taker = anchor.web3.Keypair.generate();
-
-  // Determined Seeds
-  const stateSeed = "state";
-  const authoritySeed = "authority";
-
-  // Random Seed
-  const randomSeed: anchor.BN = new anchor.BN(Math.floor(Math.random() * 100000000));
-
-  // Derive PDAs: escrowStateKey, vaultKey, vaultAuthorityKey
-  const escrowStateKey = PublicKey.findProgramAddressSync(
-    [Buffer.from(anchor.utils.bytes.utf8.encode(stateSeed)), randomSeed.toArrayLike(Buffer, "le", 8)],
+  // Determined Escrow and Vault addresses
+  const seed = new anchor.BN(randomBytes(8));
+  const escrow = PublicKey.findProgramAddressSync(
+    [Buffer.from("state"), seed.toArrayLike(Buffer, "le", 8)],
     program.programId
   )[0];
+  const vault = getAssociatedTokenAddressSync(mintA.publicKey, escrow, true);
 
-  const vaultAuthorityKey = PublicKey.findProgramAddressSync(
-    [Buffer.from(authoritySeed, "utf-8")],
-    program.programId
-  )[0];
-  let vaultKey = null as PublicKey;
+  // 2. Utils
+  // Account Wrapper
+  const accounts = {
+    initializer: initializer.publicKey,
+    taker: taker.publicKey,
+    mintA: mintA.publicKey,
+    mintB: mintB.publicKey,
+    initializerAtaA: initializerAtaA,
+    initializerAtaB: initializerAtaB,
+    takerAtaA,
+    takerAtaB,
+    escrow,
+    vault,
+    associatedTokenprogram: ASSOCIATED_TOKEN_PROGRAM_ID,
+    tokenProgram: TOKEN_PROGRAM_ID,
+    systemProgram: SystemProgram.programId,
+  };
 
-  it("Initialize program state", async () => {
-    // 1. Send 0.03 SOL from signer to payer.
-    // Please make sure that there is at least 0.03 Devnet SOL in your signer wallet.
-    // Claim Devnet SOL here: https://faucet.solana.com
+  const confirm = async (signature: string): Promise<string> => {
+    const block = await connection.getLatestBlockhash();
+    await connection.confirmTransaction({
+      signature,
+      ...block,
+    });
+    return signature;
+  };
 
-    const latestBlockhash = await anchor.getProvider().connection.getLatestBlockhash();
-
-    const airdropMessageV0 = new TransactionMessage({
-      payerKey: wallet.publicKey,
-      recentBlockhash: latestBlockhash.blockhash,
-      instructions: [
-        SystemProgram.transfer({
-          fromPubkey: wallet.publicKey,
-          toPubkey: payer.publicKey,
-          lamports: 0.03 * 10 ** 9, // Convert SOL to lamports (1 SOL = 10^9 lamports)
-        }),
-      ],
-    }).compileToV0Message();
-    const airdropTx = new VersionedTransaction(airdropMessageV0);
-    airdropTx.sign([walletKey]);
-
-    await anchor.getProvider().connection.sendTransaction(airdropTx);
-
-    // 2. Fund main roles: initializer and taker
-    const fundingTxMessageV0 = new TransactionMessage({
-      payerKey: payer.publicKey,
-      recentBlockhash: latestBlockhash.blockhash,
-      instructions: [
-        SystemProgram.transfer({
-          fromPubkey: payer.publicKey,
-          toPubkey: initializer.publicKey,
-          lamports: 10000000, // 0.01 SOL
-        }),
-        SystemProgram.transfer({
-          fromPubkey: payer.publicKey,
-          toPubkey: taker.publicKey,
-          lamports: 10000000, // 0.01 SOL
-        }),
-      ],
-    }).compileToV0Message();
-    const fundingTx = new VersionedTransaction(fundingTxMessageV0);
-    fundingTx.sign([payer]);
-
-    // console.log(Buffer.from(fundingTx.serialize()).toString("base64"));
-    const result = await anchor.getProvider().connection.sendRawTransaction(fundingTx.serialize());
-    console.log(`https://solana.fm/tx/${result}?cluster=devnet-solana`);
-
-    // 3. Create dummy token mints: mintA and mintB
-    mintA = await createMint(anchor.getProvider().connection, payer, mintAuthority.publicKey, null, 0);
-    mintB = await createMint(anchor.getProvider().connection, payer, mintAuthority.publicKey, null, 0);
-
-    // 4. Create token accounts for dummy token mints and both main roles
-    initializerTokenAccountA = await createAccount(
-      anchor.getProvider().connection,
-      initializer,
-      mintA,
-      initializer.publicKey
+  const log = async (signature: string): Promise<string> => {
+    console.log(
+      `Your transaction signature: https://explorer.solana.com/transaction/${signature}?cluster=custom&customUrl=${connection.rpcEndpoint}`
     );
-    initializerTokenAccountB = await createAccount(
-      anchor.getProvider().connection,
-      initializer,
-      mintB,
-      initializer.publicKey
-    );
-    takerTokenAccountA = await createAccount(anchor.getProvider().connection, taker, mintA, taker.publicKey);
-    takerTokenAccountB = await createAccount(anchor.getProvider().connection, taker, mintB, taker.publicKey);
+    return signature;
+  };
 
-    // 5. Mint dummy tokens to initializerTokenAccountA and takerTokenAccountB
-    await mintTo(
-      anchor.getProvider().connection,
-      initializer,
-      mintA,
-      initializerTokenAccountA,
-      mintAuthority,
-      initializerAmount
-    );
-    await mintTo(anchor.getProvider().connection, taker, mintB, takerTokenAccountB, mintAuthority, takerAmount);
+  it("Airdrop and create mints", async () => {
+    let lamports = await getMinimumBalanceForRentExemptMint(connection);
+    let tx = new Transaction();
+    tx.instructions = [
+      ...[initializer, taker].map((k) =>
+        SystemProgram.transfer({
+          fromPubkey: provider.publicKey,
+          toPubkey: k.publicKey,
+          lamports: 0.01 * LAMPORTS_PER_SOL,
+        })
+      ),
+      ...[mintA, mintB].map((m) =>
+        SystemProgram.createAccount({
+          fromPubkey: provider.publicKey,
+          newAccountPubkey: m.publicKey,
+          lamports,
+          space: MINT_SIZE,
+          programId: TOKEN_PROGRAM_ID,
+        })
+      ),
+      ...[
+        [mintA.publicKey, initializer.publicKey, initializerAtaA],
+        [mintB.publicKey, taker.publicKey, takerAtaB],
+      ].flatMap((x) => [
+        createInitializeMint2Instruction(x[0], 6, x[1], null),
+        createAssociatedTokenAccountIdempotentInstruction(provider.publicKey, x[2], x[1], x[0]),
+        createMintToInstruction(x[0], x[2], x[1], 1e9),
+      ]),
+    ];
 
-    const fetchedInitializerTokenAccountA = await getAccount(anchor.getProvider().connection, initializerTokenAccountA);
-    const fetchedTakerTokenAccountB = await getAccount(anchor.getProvider().connection, takerTokenAccountB);
-
-    assert.ok(Number(fetchedInitializerTokenAccountA.amount) == initializerAmount);
-    assert.ok(Number(fetchedTakerTokenAccountB.amount) == takerAmount);
+    await provider.sendAndConfirm(tx, [mintA, mintB, initializer, taker]).then(log);
   });
 
-  it("Initialize escrow", async () => {
-    const _vaultKey = PublicKey.findProgramAddressSync(
-      [vaultAuthorityKey.toBuffer(), TOKEN_PROGRAM_ID.toBuffer(), mintA.toBuffer()],
-      ASSOCIATED_TOKEN_PROGRAM_ID
-    )[0];
-    vaultKey = _vaultKey;
-
-    const result = await program.methods
-      .initialize(randomSeed, new anchor.BN(initializerAmount), new anchor.BN(takerAmount))
-      .accounts({
-        initializer: initializer.publicKey,
-        vaultAuthority: vaultAuthorityKey,
-        vault: vaultKey,
-        mint: mintA,
-        initializerDepositTokenAccount: initializerTokenAccountA,
-        initializerReceiveTokenAccount: initializerTokenAccountB,
-        escrowState: escrowStateKey,
-        systemProgram: anchor.web3.SystemProgram.programId,
-        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
-        tokenProgram: TOKEN_PROGRAM_ID,
-      })
+  it("Initialize", async () => {
+    const initializerAmount = 1e6;
+    const takerAmount = 1e6;
+    await program.methods
+      .initialize(seed, new anchor.BN(initializerAmount), new anchor.BN(takerAmount))
+      .accounts({ ...accounts })
       .signers([initializer])
-      .rpc();
-    console.log(`https://solana.fm/tx/${result}?cluster=devnet-solana`);
-
-    let fetchedVault = await getAccount(anchor.getProvider().connection, vaultKey);
-    let fetchedEscrowState = await program.account.escrowState.fetch(escrowStateKey);
-
-    // Check that the new owner is the PDA.
-    assert.ok(fetchedVault.owner.equals(vaultAuthorityKey));
-
-    // Check that the values in the escrow account match what we expect.
-    assert.ok(fetchedEscrowState.initializerKey.equals(initializer.publicKey));
-    assert.ok(fetchedEscrowState.initializerAmount.toNumber() == initializerAmount);
-    assert.ok(fetchedEscrowState.takerAmount.toNumber() == takerAmount);
-    assert.ok(fetchedEscrowState.initializerDepositTokenAccount.equals(initializerTokenAccountA));
-    assert.ok(fetchedEscrowState.initializerReceiveTokenAccount.equals(initializerTokenAccountB));
-  });
-
-  it("Exchange escrow state", async () => {
-    const result = await program.methods
-      .exchange()
-      .accounts({
-        taker: taker.publicKey,
-        initializerDepositTokenMint: mintA,
-        takerDepositTokenMint: mintB,
-        takerDepositTokenAccount: takerTokenAccountB,
-        takerReceiveTokenAccount: takerTokenAccountA,
-        initializerDepositTokenAccount: initializerTokenAccountA,
-        initializerReceiveTokenAccount: initializerTokenAccountB,
-        initializer: initializer.publicKey,
-        escrowState: escrowStateKey,
-        vault: vaultKey,
-        vaultAuthority: vaultAuthorityKey,
-        tokenProgram: TOKEN_PROGRAM_ID,
-      })
-      .signers([taker])
-      .rpc();
-    console.log(`https://solana.fm/tx/${result}?cluster=devnet-solana`);
-
-    let fetchedInitializerTokenAccountA = await getAccount(anchor.getProvider().connection, initializerTokenAccountA);
-    let fetchedInitializerTokenAccountB = await getAccount(anchor.getProvider().connection, initializerTokenAccountB);
-    let fetchedTakerTokenAccountA = await getAccount(anchor.getProvider().connection, takerTokenAccountA);
-    let fetchedTakerTokenAccountB = await getAccount(anchor.getProvider().connection, takerTokenAccountB);
-
-    assert.ok(Number(fetchedTakerTokenAccountA.amount) == initializerAmount);
-    assert.ok(Number(fetchedInitializerTokenAccountA.amount) == 0);
-    assert.ok(Number(fetchedInitializerTokenAccountB.amount) == takerAmount);
-    assert.ok(Number(fetchedTakerTokenAccountB.amount) == 0);
-  });
-
-  it("Initialize escrow and cancel escrow", async () => {
-    // Put back tokens into initializer token A account.
-    await mintTo(
-      anchor.getProvider().connection,
-      initializer,
-      mintA,
-      initializerTokenAccountA,
-      mintAuthority,
-      initializerAmount
-    );
-
-    const initializedTx = await program.methods
-      .initialize(randomSeed, new anchor.BN(initializerAmount), new anchor.BN(takerAmount))
-      .accounts({
-        initializer: initializer.publicKey,
-        vaultAuthority: vaultAuthorityKey,
-        vault: vaultKey,
-        mint: mintA,
-        initializerDepositTokenAccount: initializerTokenAccountA,
-        initializerReceiveTokenAccount: initializerTokenAccountB,
-        escrowState: escrowStateKey,
-        systemProgram: anchor.web3.SystemProgram.programId,
-        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
-        tokenProgram: TOKEN_PROGRAM_ID,
-      })
-      .signers([initializer])
-      .rpc();
-    console.log(`https://solana.fm/tx/${initializedTx}?cluster=devnet-solana`);
-
-    // Cancel the escrow.
-    const canceledTX = await program.methods
-      .cancel()
-      .accounts({
-        initializer: initializer.publicKey,
-        mint: mintA,
-        initializerDepositTokenAccount: initializerTokenAccountA,
-        vault: vaultKey,
-        vaultAuthority: vaultAuthorityKey,
-        escrowState: escrowStateKey,
-        tokenProgram: TOKEN_PROGRAM_ID,
-      })
-      .signers([initializer])
-      .rpc();
-    console.log(`https://solana.fm/tx/${canceledTX}?cluster=devnet-solana`);
-
-    // Check the final owner should be the provider public key.
-    const fetchedInitializerTokenAccountA = await getAccount(anchor.getProvider().connection, initializerTokenAccountA);
-
-    assert.ok(fetchedInitializerTokenAccountA.owner.equals(initializer.publicKey));
-    // Check all the funds are still there.
-    assert.ok(Number(fetchedInitializerTokenAccountA.amount) == initializerAmount);
+      .rpc()
+      .then(confirm)
+      .then(log);
   });
 });


### PR DESCRIPTION
**Notice: This refactor is inspired by [anchor-escrow-2024](https://github.com/deanmlittle/anchor-escrow-2024), written by @deanmlittle**

## Program

- Modularize contexts and states
- Use ata for initializer and taker token account
- Remove VaultAuthority, use escrow state public key as signer

## Test

- Refactor biolerplate code that is used for airdroping and creating dummy tokens
- Improve readability by extracting common accounts

TODO: Write a new anchor escrow tutorial
